### PR TITLE
Ensure `$singles` is always defined

### DIFF
--- a/src/services/SinglesList.php
+++ b/src/services/SinglesList.php
@@ -78,6 +78,7 @@ class SinglesList extends Component
         $singleSections = Craft::$app->sections->getSectionsByType(Section::TYPE_SINGLE);
 
         // Create list of Singles
+        $singles = [];
         foreach ($singleSections as $single) {
             $entry = Entry::find()
                 ->status(null)


### PR DESCRIPTION
If a user without access to any singles (via permissions or otherwise) attempts to load a page with a redactor field, they'll get a lovely `Undefined variable: singles` error. This should fix that up - just declaring it as an empty array in case the loop doesn't run/add any entries.