### PR TITLE
Ensure URL to single redirect is correct on multisite

### DIFF
--- a/src/services/SinglesList.php
+++ b/src/services/SinglesList.php
@@ -32,20 +32,21 @@ class SinglesList extends Component
         // Create list of Singles
         foreach ($singleSections as $single) {
             $entry = null;
+            $siteUrls = [];
             
             // If this is a multi-site, we need to grab the first site-enabled entry
             // Kind of annoying we can't query multiple site ids, or _all_ sites
             // https://github.com/craftcms/cms/issues/2854
             if (Craft::$app->getIsMultiSite()) {
                 foreach (Craft::$app->getSites()->getAllSiteIds() as $key => $siteId) {
-                    $entry = Entry::find()
+                    $siteEntry = Entry::find()
                         ->siteId($siteId)
                         ->status(null)
                         ->sectionId($single->id)
                         ->one();
 
-                    if ($entry) {
-                        break;
+                    if ($siteEntry) {
+                        $siteUrls[$siteId] = $siteEntry->getCpEditUrl();
                     }
                 }
             } else {
@@ -55,10 +56,10 @@ class SinglesList extends Component
                     ->one();
             }
 
-            if ($entry && Craft::$app->getUser()->checkPermission('editEntries:' . $single->uid)) {
-                $url = $entry->getCpEditUrl();
+            if (($entry || $siteUrls) && Craft::$app->getUser()->checkPermission('editEntries:' . $single->uid)) {
+                $url = $entry && !$siteUrls ? $entry->getCpEditUrl() : '';
 
-                $siteIds = ArrayHelper::getColumn($entry->getSupportedSites(), 'siteId');
+                $siteIds = $entry ? ArrayHelper::getColumn($entry->getSupportedSites(), 'siteId') : array_keys($siteUrls);;
 
                 $singles[] = [
                     'key' => 'single:' . $single->uid,
@@ -68,6 +69,7 @@ class SinglesList extends Component
                         'url' => $url,
                         'handle' => $single->handle,
                         'sites' => implode(',', $siteIds),
+                        'siteUrls' => json_encode($siteUrls),
                     ],
                     'criteria' => [
                         'sectionId' => $single->id,
@@ -92,13 +94,47 @@ class SinglesList extends Component
 
             Craft::$app->view->registerCss($css);
 
-            $js = '$(function() {' .
-                '$("#main-content #sidebar nav a[data-url]").each(function(i, e) {' .
-                    'var $link = $("<a class=\"cp-nav-link-mask\" href=" + $(this).data("url") + ">" + $(this).text() + "</a>");' .
-                    
-                    '$(this).parent().append($link);'.
-                '});' .
-            '});';
+            $js = <<<'JS'
+$(function() {
+    var $siteMenuBtn = $('#page-container').find('.sitemenubtn:first');
+    var storedSiteId = Craft.getLocalStorage('BaseElementIndex.siteId');
+
+    var updateSingleUrls = function(siteId = null) {
+        $("#main-content #sidebar nav a[data-url]").each(function(i, e) {
+            var url = siteId != null && $(this).data("siteurls")[siteId] ? $(this).data("siteurls")[siteId] : $(this).data("url");
+
+            if (!url) return;
+
+            // Update if overlay link already exists, create and append if not
+            var $link = $(this).parent().find('a.cp-nav-link-mask');
+            if ($link.length) {
+                $link.attr('href', url);
+            } else {
+                $link = $("<a class=\"cp-nav-link-mask\" href=" + url + ">" + $(this).text() + "</a>");
+                $(this).parent().append($link);
+            }
+        });
+    }
+
+    var onSelect = function(ev) {
+        var $option = $(ev.selectedOption);
+        updateSingleUrls($option.data('site-id'));
+    }
+
+    // If we have a site menu
+    if ($siteMenuBtn.length) {
+        // Set links to stored siteId
+        updateSingleUrls(storedSiteId);
+
+        // Add listener when selecting site
+        this.siteMenu = $siteMenuBtn.menubtn().data('menubtn').menu;
+        this.siteMenu.on('optionselect', onSelect);
+    } else {
+        // Set links to default link
+        updateSingleUrls();
+    }
+});
+JS;
 
             Craft::$app->view->registerJs($js);
         }


### PR DESCRIPTION
When loading entries or changing site on a multisite installation and "Redirect to Entry" is enabled, the URL does not link to the correct site.

This PR fixes this by listening to changes in the current site and updating the links, in addition to initializing with the currently set siteId from localstorage.